### PR TITLE
Expand emoji set to cover all 21 slider values

### DIFF
--- a/app/mobile/src/main/java/com/moodfox/ui/checkin/CheckInScreen.kt
+++ b/app/mobile/src/main/java/com/moodfox/ui/checkin/CheckInScreen.kt
@@ -50,15 +50,33 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.launch
 import org.json.JSONArray
-import kotlin.math.abs
 
-// ── Emoji anchors (5 key points) ────────────────────────
+// ── Emoji for every step on the scale ────────────────────
 private val SCALE_EMOJIS = mapOf(
-    -10 to "😭", -5 to "😔", 0 to "😐", 5 to "😊", 10 to "🤩",
+    -10 to "😭",
+    -9  to "😩",
+    -8  to "😢",
+    -7  to "😟",
+    -6  to "😞",
+    -5  to "😔",
+    -4  to "😕",
+    -3  to "🙁",
+    -2  to "😐",
+    -1  to "😑",
+     0  to "🙂",
+     1  to "😊",
+     2  to "😌",
+     3  to "😀",
+     4  to "😄",
+     5  to "😁",
+     6  to "🤩",
+     7  to "😎",
+     8  to "🥳",
+     9  to "😍",
+    10  to "🤯",
 )
 
-private fun emojiForValue(value: Int): String =
-    SCALE_EMOJIS.entries.minByOrNull { abs(it.key - value) }?.value ?: "😐"
+private fun emojiForValue(value: Int): String = SCALE_EMOJIS[value.coerceIn(-10, 10)] ?: "🙂"
 
 // ── Mood color ────────────────────────────────────────────
 @Composable


### PR DESCRIPTION
Closes #4

## What changed

Replaced the 5-point emoji anchor map with a full 21-entry map covering every integer from −10 to +10:

| −10 | −9 | −8 | −7 | −6 | −5 | −4 | −3 | −2 | −1 | 0 | +1 | +2 | +3 | +4 | +5 | +6 | +7 | +8 | +9 | +10 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 😭 | 😩 | 😢 | 😟 | 😞 | 😔 | 😕 | 🙁 | 😐 | 😑 | 🙂 | 😊 | 😌 | 😀 | 😄 | 😁 | 🤩 | 😎 | 🥳 | 😍 | 🤯 |

`emojiForValue()` is now a direct map lookup with `coerceIn(-10, 10)` — no more nearest-key search needed. Removed the now-unused `kotlin.math` import.