### PR TITLE
Fix note field hidden behind keyboard on check-in screen

### DIFF
--- a/app/mobile/src/main/java/com/moodfox/ui/checkin/CheckInScreen.kt
+++ b/app/mobile/src/main/java/com/moodfox/ui/checkin/CheckInScreen.kt
@@ -678,13 +678,21 @@ private fun NoteCard(
                     modifier           = Modifier.size(16.dp),
                 )
                 Spacer(Modifier.width(10.dp))
-                Text(
-                    text     = if (note.isBlank()) stringResource(R.string.checkin_note_add) else note,
-                    style    = MaterialTheme.typography.bodyMedium,
-                    color    = if (note.isBlank()) colors.onSurfaceVariant else colors.onSurface,
-                    maxLines = if (showNote) Int.MAX_VALUE else 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                if (!showNote) {
+                    Text(
+                        text     = if (note.isBlank()) stringResource(R.string.checkin_note_add) else note,
+                        style    = MaterialTheme.typography.bodyMedium,
+                        color    = if (note.isBlank()) colors.onSurfaceVariant else colors.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                } else {
+                    Text(
+                        text  = stringResource(R.string.checkin_note_add),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colors.onSurfaceVariant,
+                    )
+                }
             }
             val focusRequester = remember { FocusRequester() }
             LaunchedEffect(showNote) {


### PR DESCRIPTION
Closes #7

## Problem
When typing a long note on the check-in screen:
1. The keyboard covered the bottom of the screen — the note field and save button were partially or fully hidden behind it
2. As text wrapped to new lines, the cursor / latest line scrolled out of view beneath the keyboard with no auto-scroll

## Fix

**`imePadding()` on the outer `Box`** — the whole screen layout (scrollable content + sticky save button) now shrinks appropriately when the software keyboard is raised, so nothing is hidden behind it.

**`BringIntoViewRequester` on the `OutlinedTextField`** — a `LaunchedEffect(note)` calls `bringIntoViewRequester.bringIntoView()` every time the text changes, keeping the bottom of the field (i.e. the current cursor line) scrolled into view throughout the typing session.